### PR TITLE
Add storage-by-bit feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ await fs_unlink('Documents', 'hello.txt', {
   }
 });
 ```
+
+Store and retrieve bits efficiently
+```js
+await storageSetBit('Documents', 'feature-flags', 3, true);
+const isEnabled = await storageGetBit('Documents', 'feature-flags', 3);
+
+// Reset a bitfield entirely
+await storageClearBits('Documents', 'feature-flags');
+```
 Notes
 
 Each directory is a separate `localForage` instance under the hood.

--- a/fs.js
+++ b/fs.js
@@ -1,6 +1,44 @@
 import { openDB } from 'https://cdn.jsdelivr.net/npm/idb@8.0.3/+esm';
 import localforage from 'https://cdn.jsdelivr.net/npm/localforage@1.10.0/+esm';
 
+const BIT_DB_NAME = 'browserfs-bit-storage';
+const BIT_STORE_NAME = 'bitfields';
+
+const bitDBPromise = openDB(BIT_DB_NAME, 1, {
+  upgrade(db) {
+    if (!db.objectStoreNames.contains(BIT_STORE_NAME)) {
+      db.createObjectStore(BIT_STORE_NAME);
+    }
+  },
+});
+
+const BIT_KEY_PREFIX = '__bit__';
+
+function makeBitKey(dir, fileName) {
+  return `${BIT_KEY_PREFIX}:${dir}/${fileName}`;
+}
+
+function ensureIntegerBitIndex(bitIndex) {
+  if (!Number.isInteger(bitIndex) || bitIndex < 0) {
+    throw new TypeError('bitIndex must be a non-negative integer');
+  }
+}
+
+function normaliseBitValue(value) {
+  return Boolean(value);
+}
+
+function toUint8Array(payload) {
+  if (!payload) return null;
+  if (payload instanceof Uint8Array) return payload;
+  if (payload instanceof ArrayBuffer) return new Uint8Array(payload);
+  if (ArrayBuffer.isView(payload)) {
+    return new Uint8Array(payload.buffer.slice(payload.byteOffset, payload.byteOffset + payload.byteLength));
+  }
+  if (Array.isArray(payload)) return Uint8Array.from(payload);
+  return null;
+}
+
 // Track "directories" as localForage instances
 const directories = {};
 
@@ -40,3 +78,86 @@ async function fs_unlink(dir, fileName, { blocked } = {}) {
     else console.error(`Failed to delete "${fileName}":`, err);
   }
 }
+
+async function getBitfield(key, minBits = 0) {
+  const db = await bitDBPromise;
+  const stored = await db.get(BIT_STORE_NAME, key);
+  let bitfield;
+  if (!stored) {
+    bitfield = new Uint8Array(Math.ceil(minBits / 8));
+  } else {
+    bitfield = toUint8Array(stored);
+  }
+
+  if (!bitfield) {
+    throw new TypeError('Stored bitfield is not a supported binary type');
+  }
+
+  const requiredBytes = Math.ceil(minBits / 8);
+  if (requiredBytes > bitfield.length) {
+    const expanded = new Uint8Array(requiredBytes);
+    expanded.set(bitfield);
+    bitfield = expanded;
+  }
+
+  return bitfield;
+}
+
+async function persistBitfield(key, bitfield) {
+  const db = await bitDBPromise;
+  await db.put(BIT_STORE_NAME, bitfield, key);
+}
+
+async function storageSetBit(dir, fileName, bitIndex, value) {
+  ensureIntegerBitIndex(bitIndex);
+  const bitValue = normaliseBitValue(value);
+  const key = makeBitKey(dir, fileName);
+  const totalBits = bitIndex + 1;
+  const bitfield = await getBitfield(key, totalBits);
+
+  const byteIndex = Math.floor(bitIndex / 8);
+  const mask = 1 << (bitIndex % 8);
+
+  if (bitValue) {
+    bitfield[byteIndex] |= mask;
+  } else {
+    bitfield[byteIndex] &= ~mask;
+  }
+
+  await persistBitfield(key, bitfield);
+  return bitValue;
+}
+
+async function storageGetBit(dir, fileName, bitIndex) {
+  ensureIntegerBitIndex(bitIndex);
+  const key = makeBitKey(dir, fileName);
+  const db = await bitDBPromise;
+  const stored = await db.get(BIT_STORE_NAME, key);
+  if (!stored) return false;
+
+  const bitfield = toUint8Array(stored);
+  if (!bitfield) {
+    throw new TypeError('Stored bitfield is not a supported binary type');
+  }
+
+  const byteIndex = Math.floor(bitIndex / 8);
+  if (byteIndex >= bitfield.length) return false;
+  const mask = 1 << (bitIndex % 8);
+  return (bitfield[byteIndex] & mask) !== 0;
+}
+
+async function storageClearBits(dir, fileName) {
+  const key = makeBitKey(dir, fileName);
+  const db = await bitDBPromise;
+  await db.delete(BIT_STORE_NAME, key);
+}
+
+export {
+  os_mkdir,
+  writeFile,
+  readFile,
+  fs_unlink,
+  storageSetBit,
+  storageGetBit,
+  storageClearBits,
+};


### PR DESCRIPTION
## Summary
- add IndexedDB-backed helpers for storing and reading individual bits by key
- expose APIs to set, get, and clear bitfields alongside existing filesystem helpers
- document the new bit storage usage pattern in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d71f658fb883208f7c74508edc6786