### PR TITLE
Rename BrowserFS references to BRFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-BrowserFS
+BRFS
 
-A lightweight Node-style filesystem for browsers using localForage and idb.
+Formerly known as BrowserFS, BRFS is a lightweight Node-style filesystem for browsers using localForage and idb. The new name avoids confusion with other projects that share the BrowserFS name.
 Simulate directories, read/write files, and delete them—all with familiar fs-style functions.
 
 Features
@@ -18,7 +18,7 @@ Installation
 Include via ES modules:
 ```html
 <script type="module">
-  import { os_mkdir, writeFile, readFile, fs_unlink } from './browserfs.js';
+  import { os_mkdir, writeFile, readFile, fs_unlink } from './brfs.js';
 </script>
 ```
 
@@ -33,12 +33,12 @@ const myDir = os_mkdir('Documents');
 ```
 Write a file
 ```js
-await writeFile('Documents', 'hello.txt', 'Hello BrowserFS!');
+await writeFile('Documents', 'hello.txt', 'Hello BRFS!');
 ```
 Read a file
 ```js
 const content = await readFile('Documents', 'hello.txt');
-console.log(content); // "Hello BrowserFS!"
+console.log(content); // "Hello BRFS!"
 ```
 Delete a file
 ```js

--- a/brfs.js
+++ b/brfs.js
@@ -1,7 +1,7 @@
 import { openDB } from 'https://cdn.jsdelivr.net/npm/idb@8.0.3/+esm';
 import localforage from 'https://cdn.jsdelivr.net/npm/localforage@1.10.0/+esm';
 
-const BIT_DB_NAME = 'browserfs-bit-storage';
+const BIT_DB_NAME = 'brfs-bit-storage';
 const BIT_STORE_NAME = 'bitfields';
 
 const bitDBPromise = openDB(BIT_DB_NAME, 1, {


### PR DESCRIPTION
## Summary
- rename the public documentation and module from BrowserFS to BRFS to avoid confusion
- update the ES module example import and sample output to use the new name
- update the bitfield storage identifier to reflect the BRFS rename

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d84db7aeb88320bd2e5b53ad8a8f60