### PR TITLE
Fix storageSetBit transaction race

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -39,6 +39,28 @@ function toUint8Array(payload) {
   return null;
 }
 
+function prepareBitfield(stored, minBits = 0) {
+  let bitfield;
+  if (!stored) {
+    bitfield = new Uint8Array(Math.ceil(minBits / 8));
+  } else {
+    bitfield = toUint8Array(stored);
+  }
+
+  if (!bitfield) {
+    throw new TypeError('Stored bitfield is not a supported binary type');
+  }
+
+  const requiredBytes = Math.ceil(minBits / 8);
+  if (requiredBytes > bitfield.length) {
+    const expanded = new Uint8Array(requiredBytes);
+    expanded.set(bitfield);
+    bitfield = expanded;
+  }
+
+  return bitfield;
+}
+
 // Track "directories" as localForage instances
 const directories = {};
 
@@ -82,30 +104,7 @@ async function fs_unlink(dir, fileName, { blocked } = {}) {
 async function getBitfield(key, minBits = 0) {
   const db = await bitDBPromise;
   const stored = await db.get(BIT_STORE_NAME, key);
-  let bitfield;
-  if (!stored) {
-    bitfield = new Uint8Array(Math.ceil(minBits / 8));
-  } else {
-    bitfield = toUint8Array(stored);
-  }
-
-  if (!bitfield) {
-    throw new TypeError('Stored bitfield is not a supported binary type');
-  }
-
-  const requiredBytes = Math.ceil(minBits / 8);
-  if (requiredBytes > bitfield.length) {
-    const expanded = new Uint8Array(requiredBytes);
-    expanded.set(bitfield);
-    bitfield = expanded;
-  }
-
-  return bitfield;
-}
-
-async function persistBitfield(key, bitfield) {
-  const db = await bitDBPromise;
-  await db.put(BIT_STORE_NAME, bitfield, key);
+  return prepareBitfield(stored, minBits);
 }
 
 async function storageSetBit(dir, fileName, bitIndex, value) {
@@ -113,7 +112,11 @@ async function storageSetBit(dir, fileName, bitIndex, value) {
   const bitValue = normaliseBitValue(value);
   const key = makeBitKey(dir, fileName);
   const totalBits = bitIndex + 1;
-  const bitfield = await getBitfield(key, totalBits);
+  const db = await bitDBPromise;
+  const tx = db.transaction(BIT_STORE_NAME, 'readwrite');
+  const store = tx.store;
+  const stored = await store.get(key);
+  const bitfield = prepareBitfield(stored, totalBits);
 
   const byteIndex = Math.floor(bitIndex / 8);
   const mask = 1 << (bitIndex % 8);
@@ -124,7 +127,8 @@ async function storageSetBit(dir, fileName, bitIndex, value) {
     bitfield[byteIndex] &= ~mask;
   }
 
-  await persistBitfield(key, bitfield);
+  await store.put(bitfield, key);
+  await tx.done;
   return bitValue;
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- add IndexedDB-backed helpers for storing and reading individual bits by key
- expose APIs to set, get, and clear bitfields alongside existing filesystem helpers
- document the new bit storage usage pattern in the README
- ensure storageSetBit mutates bitfields within a single readwrite transaction to avoid dropping concurrent updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea8c7a36308320ac3a8d8e432b06a9


___

### **PR Type**
Bug fix


___

### **Description**
- Fix race condition in `storageSetBit` using atomic transactions

- Refactor bitfield preparation logic into reusable helper

- Remove separate `persistBitfield` function for direct transaction control

- Ensure concurrent bit updates don't get lost


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["storageSetBit call"] --> B["Start readwrite transaction"]
  B --> C["Get stored bitfield"]
  C --> D["Prepare bitfield with prepareBitfield"]
  D --> E["Apply bit operation"]
  E --> F["Store updated bitfield"]
  F --> G["Commit transaction"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fs.js</strong><dd><code>Fix storageSetBit race condition with atomic transactions</code></dd></summary>
<hr>

fs.js

<ul><li>Added <code>prepareBitfield</code> helper function to handle bitfield <br>initialization and expansion<br> <li> Modified <code>storageSetBit</code> to use atomic IndexedDB transactions instead of <br>separate read/write operations<br> <li> Refactored <code>getBitfield</code> to use the new <code>prepareBitfield</code> helper<br> <li> Removed <code>persistBitfield</code> function as it's no longer needed</ul>


</details>


  </td>
  <td><a href="https://github.com/eotter-beep/brfs/pull/3/files#diff-a0117c902da2e01bf2bcb1be0ab30ea20affab56c6fe8545379a13da9a321553">+30/-26</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

